### PR TITLE
always allocate original for empty visitor ID

### DIFF
--- a/src/Allocation.php
+++ b/src/Allocation.php
@@ -15,11 +15,17 @@ final class Allocation
      * The allocation is the same given the same project ID, visitor ID, variation IDs, variation order,
      * and variation weights, but it appears random given randomly distributed visitor IDs.
      *
+     * If the visitor ID is empty, always returns the original variation.
+     *
      * @return VariationConfig the allocated variation
      * @throws \Exception if the variation weight configuration in $project is invalid
      */
     public static function findVariationForVisitor(ProjectConfig $project, string $visitorID): VariationConfig
     {
+        if ('' === $visitorID) {
+            return $project->findVariationWithName('Original') ?: self::lookupVariationAt($project, 1);
+        }
+
         $allocation = self::getAllocation($project, $visitorID);
 
         return self::lookupVariationAt($project, $allocation);

--- a/src/Config/ProjectConfig.php
+++ b/src/Config/ProjectConfig.php
@@ -54,4 +54,15 @@ final class ProjectConfig
         return null;
     }
 
+    function findVariationWithName(string $variationName): ?VariationConfig
+    {
+        foreach ($this->variations as $variation) {
+            if ($variation->name === $variationName) {
+                return $variation;
+            }
+        }
+
+        return null;
+    }
+
 }

--- a/tests/AllocationTest.php
+++ b/tests/AllocationTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Symplify\SSTSDK\Allocation;
 use Symplify\SSTSDK\Config\ProjectConfig;
 use Symplify\SSTSDK\Config\SymplifyConfig;
+use Symplify\SSTSDK\Config\VariationConfig;
 use function PHPUnit\Framework\assertEquals;
 
 const ALLOCATION_TEST_PROJECT_JSON = '
@@ -61,8 +62,26 @@ final class AllocationTest extends TestCase
 
     public function testAllocateEmptyVisitorID(): void
     {
-        $variation = Allocation::findVariationForVisitor($this->testProject, "");
-        assertEquals(42, $variation->id);
+        $originalID = random_int(1, 1000);
+        $variationID = random_int(1001, 2000);
+        $testProject = new ProjectConfig(
+            10000,
+            'test project',
+            [
+                new VariationConfig(
+                    $originalID,
+                    'Original',
+                    1,
+                ),
+                new VariationConfig(
+                    $variationID,
+                    'Variation',
+                    1000,
+                ),
+            ]
+        );
+        $variation = Allocation::findVariationForVisitor($testProject, "");
+        assertEquals($originalID, $variation->id);
     }
 
     public function testAllocateLongVisitorID(): void


### PR DESCRIPTION
We want the variation allocation to be as robust and stable as possible. If the visitor ID could not be generated (e.g. there was no appropriate source of randomness) we should prefer to always allocate the original variation.