### PR TITLE
Align cookies with jssdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor/
 
 examples/.cache-*
+/.phpunit.result.cache

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -79,7 +79,11 @@
     <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration"/>
     <rule ref="SlevomatCodingStandard.Functions.DisallowEmptyFunction"/>
     <rule ref="SlevomatCodingStandard.Functions.DisallowNamedArguments"/>
-    <rule ref="SlevomatCodingStandard.Functions.FunctionLength"/>
+    <rule ref="SlevomatCodingStandard.Functions.FunctionLength">
+        <properties>
+            <property name="maxLinesLength" value="30"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.Functions.RequireMultiLineCall"/>
     <rule ref="SlevomatCodingStandard.Functions.RequireSingleLineCall"/>
     <rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>

--- a/src/Client.php
+++ b/src/Client.php
@@ -129,7 +129,7 @@ final class Client
                 return null;
             }
 
-            $visitorID      = Visitor::ensureVisitorID(new DefaultCookieJar(), $this->logger);
+            $visitorID      = Visitor::ensureVisitorID(new DefaultCookieJar(), $this->logger, $this->websiteID);
             $foundVariation = Allocation::findVariationForVisitor($foundProject, $visitorID);
 
             return $foundVariation->name;

--- a/tests/VisitorTest.php
+++ b/tests/VisitorTest.php
@@ -13,30 +13,55 @@ use function PHPUnit\Framework\assertNotEquals;
 final class VisitorTest extends TestCase
 {
 
-    public function testSetCookie(): void
+    private const JSON_COOKIE_NAME = 'sg_cookies';
+    private const VISITOR_ID_COOKIE_KEY = 'visid';
+
+    public function testSetJsonCookie(): void
     {
-        $logger = new NullLogger();
-        $cookies = newCookieJar();
-        $returnedID = Visitor::ensureVisitorID($cookies, $logger, generateConstantID('goober'));
+        $logger        = new NullLogger();
+        $cookies       = newCookieJar();
+        $testWebsiteID = '4711';
+
+        $returnedID = Visitor::ensureVisitorID($cookies, $logger, $testWebsiteID, generateConstantID('goober'));
+        $cookieObj  = json_decode($cookies->getCookie(self::JSON_COOKIE_NAME), true);
+
         assertEquals('goober', $returnedID);
-        assertEquals('goober', $cookies->getCookie('sg_sst_vid'));
+        assertEquals('goober', $cookieObj[$testWebsiteID][self::VISITOR_ID_COOKIE_KEY]);
     }
 
-    public function testReuseCookie(): void
+    public function testReuseJsonCookie(): void
     {
-        $logger = new NullLogger();
+        $logger  = new NullLogger();
         $cookies = newCookieJar();
-        $returnedIDA = Visitor::ensureVisitorID($cookies, $logger, generateConstantID('goober'));
-        $returnedIDB = Visitor::ensureVisitorID($cookies, $logger, generateConstantID('flubber'));
-        assertEquals('goober', $returnedIDA);
-        assertEquals('goober', $returnedIDB);
+
+        // phpcs:ignore
+        $rawCookie  = '{%2210001%22:{%22100000002%22:[300001]%2C%22100000001%22:[300002]%2C%22100000002_ch%22:1%2C%22100000001_ch%22:1%2C%22lv%22:1650967549303%2C%22rf%22:%22%22%2C%22pv%22:2%2C%22pv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22tv%22:2%2C%22tv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22aud_p%22:[100000002%2C100000001]%2C%22visid%22:%2278ac2972-de5f-4262-bfdb-7296eb132a94%22%2C%22commid%22:%221be9f08d-c36c-4bce-b157-e057e050027c%22}%2C%22_g%22:1}';
+        $cookieJSON = urldecode($rawCookie); // PHP does this automatically for $_COOKIE
+        $cookies->setCookie(self::JSON_COOKIE_NAME, $cookieJSON);
+
+        $returnedID = Visitor::ensureVisitorID($cookies, $logger, '10001', generateConstantID('goober'));
+        assertEquals('78ac2972-de5f-4262-bfdb-7296eb132a94', $returnedID);
+    }
+
+    public function testAbortOnUnknownJsonCookieVersion(): void
+    {
+        $logger  = new NullLogger();
+        $cookies = newCookieJar();
+
+        // phpcs:ignore
+        $rawCookie  = '{%2210001%22:{%22100000002%22:[300001]%2C%22100000001%22:[300002]%2C%22100000002_ch%22:1%2C%22100000001_ch%22:1%2C%22lv%22:1650967549303%2C%22rf%22:%22%22%2C%22pv%22:2%2C%22pv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22tv%22:2%2C%22tv_p%22:{%22100000002%22:2%2C%22100000001%22:2}%2C%22aud_p%22:[100000002%2C100000001]%2C%22visid%22:%2278ac2972-de5f-4262-bfdb-7296eb132a94%22%2C%22commid%22:%221be9f08d-c36c-4bce-b157-e057e050027c%22}%2C%22_g%22:1000000}';
+        $cookieJSON = urldecode($rawCookie); // PHP does this automatically for $_COOKIE
+        $cookies->setCookie(self::JSON_COOKIE_NAME, $cookieJSON);
+
+        $returnedID = Visitor::ensureVisitorID($cookies, $logger, '42', generateConstantID('goober'));
+        assertEquals('', $returnedID);
     }
 
     public function testGenerateUUID(): void
     {
-        $logger = new NullLogger();
-        $returnedIDA = Visitor::ensureVisitorID(newCookieJar(), $logger);
-        $returnedIDB = Visitor::ensureVisitorID(newCookieJar(), $logger);
+        $logger      = new NullLogger();
+        $returnedIDA = Visitor::ensureVisitorID(newCookieJar(), $logger, "doesn't matter");
+        $returnedIDB = Visitor::ensureVisitorID(newCookieJar(), $logger, "don't care");
         $uuidPattern = '/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/';
         assertMatchesRegularExpression($uuidPattern, $returnedIDA);
         assertMatchesRegularExpression($uuidPattern, $returnedIDB);


### PR DESCRIPTION
Problem
======

While first developing the SST SDK we used a placeholder cookie for the visitor ID. To better integrate with frontend logic when needed, and prepare for upcoming features, we need to be compatible with the same cookie format.

Solution
======

* Read and write the ID inside the JSON cookie instead of the placeholder SST cookie.
* Ensure the cookie version is known before using it.

Testing
=====

See updated unit tests.

I also tested the example servers with curl to double check end-to-end that a cookie from production works. We should look at automating integration/end-to-end tests.