### PR TITLE
Update Example Code Dependency Guzzle to 7.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+###Changed
+- Bump guzzle dependency in example code (CVE-2022-31042, CVE-2022-31043)
 
 ## [0.1.1] - 2022-05-31
 ### Changed

--- a/examples/composer.json
+++ b/examples/composer.json
@@ -9,7 +9,7 @@
   "require": {
     "php": ">=7.4",
     "ext-fileinfo": "*",
-    "guzzlehttp/guzzle": "7.4.3",
+    "guzzlehttp/guzzle": "7.4.4",
     "kevinrob/guzzle-cache-middleware":"v4.0.1.",
     "kodus/file-cache": "1.1.1",
     "symplify-conversion/sst-sdk-php": "dev-main"

--- a/examples/composer.lock
+++ b/examples/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7275fc9df9bdc350f69a2a9a95fbc21",
+    "content-hash": "2375663a7992a30b3654e384681c6db8",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.4.3",
+            "version": "7.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "74a8602c6faec9ef74b7a9391ac82c5e65b1cdab"
+                "reference": "e3ff079b22820c2029d4c2a87796b6a0b8716ad8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/74a8602c6faec9ef74b7a9391ac82c5e65b1cdab",
-                "reference": "74a8602c6faec9ef74b7a9391ac82c5e65b1cdab",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/e3ff079b22820c2029d4c2a87796b6a0b8716ad8",
+                "reference": "e3ff079b22820c2029d4c2a87796b6a0b8716ad8",
                 "shasum": ""
             },
             "require": {
@@ -112,7 +112,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.4.3"
+                "source": "https://github.com/guzzle/guzzle/tree/7.4.4"
             },
             "funding": [
                 {
@@ -128,7 +128,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-25T13:24:33+00:00"
+            "time": "2022-06-09T21:39:15+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -846,7 +846,7 @@
             "dist": {
                 "type": "path",
                 "url": "..",
-                "reference": "a7e13f39df442f6316e8d5e2eca23e3860af7400"
+                "reference": "6f542659ca23ea16a91c4f8251a835ed8ca7d369"
             },
             "require": {
                 "ext-curl": "*",


### PR DESCRIPTION
Problem
======

Dependabot alerted us to two Guzzle issues:
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-31042
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-31043

It's just in our example code, but there is no reason to not update.

Solution
======

Bump the dep to install fixed versions.

Testing
=====

I tested the `WithCustomHttpClient.php` example and it still works fine.