### PR TITLE
set cookie options: domain, expires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- cookies: make domain overridable, set expires
 - persist allocations in cookie, we want it stable even if config changes
 - add data driven SDK compatibility test suite
 ### Changed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Changes
 
 See [CHANGELOG.md](./CHANGELOG.md)
 
-
 Requirements
 ============
 
@@ -158,13 +157,15 @@ $ act -P ubuntu-latest=shivammathur/node:latest
 
 ## Local Testing
 
-The `examples` directory contains example scripts to show how to use the SDK, but they are also a nice way to test
-locally during development.
+The `examples` directory contains example scripts to show how to use the SDK,
+but they are also a nice way to test locally during development.
+They expect symplify-demoapp.localhost.test and fake-cdn.localhost.test to be
+names for 127.0.0.1 in your hosts file.
 
 ```
 # this starts php, serving the contents of examples, with some setup for the SDK
 $ (cd examples; ./example-server.sh) &
-$ curl http://localhost:8910/WithCustomHttpClient.php
+$ curl http://symplify-demoapp.localhost.test:8910/WithCustomHttpClient.php
 [Wed Apr 13 18:51:56 2022] 127.0.0.1:52273 Accepted
 [Wed Apr 13 18:51:56 2022] 127.0.0.1:52274 Accepted
 [Wed Apr 13 18:51:56 2022] 127.0.0.1:52274 [INFO] ExamplesCDN: GET /4711/sstConfig.json
@@ -174,7 +175,7 @@ $ curl http://localhost:8910/WithCustomHttpClient.php
  * discount
    - assigned variation: original
 
-$ curl http://localhost:8910/WithCustomHttpClient.php
+$ curl http://symplify-demoapp.localhost.test:8910/WithCustomHttpClient.php
 [Wed Apr 13 18:51:58 2022] 127.0.0.1:52275 Accepted
 [Wed Apr 13 18:51:58 2022] 127.0.0.1:52275 [200]: GET /WithCustomHttpClient.php
 [Wed Apr 13 18:51:58 2022] 127.0.0.1:52275 Closing
@@ -185,7 +186,7 @@ $ curl http://localhost:8910/WithCustomHttpClient.php
 
 You can get stable variation allocations by configuring curl for cookies e.g.
 ```
-curl --cookie cookiejar.txt --cookie-jar cookiejar.txt http://localhost:8910/Hello.php
+curl --cookie cookiejar.txt --cookie-jar cookiejar.txt http://symplify-demoapp.localhost.test:8910/Hello.php
 ```
 
 ## Troubleshooting

--- a/examples/Hello.php
+++ b/examples/Hello.php
@@ -7,8 +7,13 @@ use SymplifyConversion\SSTSDK\Config\ClientConfig;
 
 $websiteID  = "4711";
 $cdnBaseURL = getenv('SSTSDK_CDN_BASEURL');
+$cookieDomain = getenv('SSTSDK_COOKIE_DOMAIN');
 
-$clientConfig = (new ClientConfig($websiteID))->withCdnBaseURL($cdnBaseURL);
+if (!$cookieDomain) {
+    $cookieDomain = ".localhost.test";
+}
+
+$clientConfig = (new ClientConfig($websiteID, $cookieDomain))->withCdnBaseURL($cdnBaseURL);
 $sdk          = new SymplifyClient($clientConfig);
 
 $sdk->loadConfig();

--- a/examples/WithCustomHttpClient.php
+++ b/examples/WithCustomHttpClient.php
@@ -16,6 +16,12 @@ use SymplifyConversion\SSTSDK\Config\ClientConfig as SymplifyClientConfig;
 $websiteID  = "4711";
 $cdnBaseURL = getenv('SSTSDK_CDN_BASEURL');
 
+$cookieDomain = getenv('SSTSDK_COOKIE_DOMAIN');
+
+if (!$cookieDomain) {
+    $cookieDomain = ".localhost.test";
+}
+
 $cache           = new Psr16CacheStorage(new FileCache('/tmp/sstsdk-examples-httpcache', 500));
 $cacheMiddleware = new CacheMiddleware(new PublicCacheStrategy($cache));
 $stack           = HandlerStack::create();
@@ -24,7 +30,7 @@ $stack->push($cacheMiddleware, 'cache');
 $httpClient   = new HttpClient(['handler' => $stack]);
 $httpRequests = new HttpFactory();
 
-$clientConfig = (new SymplifyClientConfig($websiteID))
+$clientConfig = (new SymplifyClientConfig($websiteID, $cookieDomain))
     ->withCdnBaseURL($cdnBaseURL)
     ->withHttpClient($httpClient)
     ->withHttpRequests($httpRequests);

--- a/examples/WithCustomLogger.php
+++ b/examples/WithCustomLogger.php
@@ -12,7 +12,13 @@ $missingProject = filter_input(INPUT_GET, 'missingProject', FILTER_VALIDATE_BOOL
 $websiteID  = $badJSON ? "42" : "4711";
 $cdnBaseURL = getenv('SSTSDK_CDN_BASEURL');
 
-$clientConfig = (new ClientConfig($websiteID))
+$cookieDomain = getenv('SSTSDK_COOKIE_DOMAIN');
+
+if (!$cookieDomain) {
+    $cookieDomain = ".localhost.test";
+}
+
+$clientConfig = (new ClientConfig($websiteID, $cookieDomain))
     ->withLogger(new ErrorLogLogger())
     ->withCdnBaseURL($cdnBaseURL);
 

--- a/examples/example-server.sh
+++ b/examples/example-server.sh
@@ -10,8 +10,8 @@ then
   exit 1
 fi
 
-EXAMPLE_SERVER_ADDR=${EXAMPLE_SERVER_ADDR:-localhost:8910}
-EXAMPLE_CDN_ADDR=${EXAMPLE_CDN_ADDR:-localhost:8911}
+EXAMPLE_SERVER_ADDR=${EXAMPLE_SERVER_ADDR:-symplify-demoapp.localhost.test:8910}
+EXAMPLE_CDN_ADDR=${EXAMPLE_CDN_ADDR:-fake-cdn.localhost.test:8911}
 
 # SSTSDK_* variables are not special, they just happen to be used by example scripts
 export SSTSDK_CDN_BASEURL="http://$EXAMPLE_CDN_ADDR"

--- a/src/Config/ClientConfig.php
+++ b/src/Config/ClientConfig.php
@@ -32,7 +32,14 @@ final class ClientConfig
     /** @var LoggerInterface a logger to collect messages from the SDK */
     private LoggerInterface $logger;
 
-    function __construct(string $websiteID)
+    /** @var ?string override the domain for which to write Symplify cookies */
+    private ?string $cookieDomain;
+
+    /**
+     * @param string      $websiteID your website ID
+     * @param string|null $cookieDomain set to override the domain for Symplify cookie writing
+     */
+    function __construct(string $websiteID, ?string $cookieDomain = null)
     {
         $this->websiteID        = $websiteID;
         $this->cdnBaseURL       = self::DEFAULT_CDN_BASEURL;
@@ -40,6 +47,7 @@ final class ClientConfig
         $this->httpClient       = null;
         $this->httpRequests     = null;
         $this->logger           = new NullLogger();
+        $this->cookieDomain     = $cookieDomain;
     }
 
     public function getWebsiteID(): string
@@ -115,6 +123,20 @@ final class ClientConfig
     public function getLogger(): LoggerInterface
     {
         return $this->logger;
+    }
+
+    public function withCookieDomain(string $newCookieDomain): ClientConfig
+    {
+        $copy = clone $this;
+
+        $copy->cookieDomain = $newCookieDomain;
+
+        return $copy;
+    }
+
+    public function getCookieDomain(): ?string
+    {
+        return $this->cookieDomain;
     }
 
 }

--- a/src/Cookies/CookieJar.php
+++ b/src/Cookies/CookieJar.php
@@ -15,8 +15,10 @@ interface CookieJar
 
     /**
      * Set the HTTP cookie for the current response, with the given name, the given value.
+     * The expires field of the cookie must be `$expireInDays` days from now.
+     * The domain field of the cookie should be the domain you run your test projects on.
      * The cookie value should be URL encoded.
      */
-    public function setCookie(string $name, string $value): void;
+    public function setCookie(string $name, string $value, int $expireInDays): void;
 
 }

--- a/src/Cookies/DefaultCookieJar.php
+++ b/src/Cookies/DefaultCookieJar.php
@@ -7,6 +7,17 @@ namespace SymplifyConversion\SSTSDK\Cookies;
 final class DefaultCookieJar implements CookieJar
 {
 
+    private ?string $cookieDomain;
+
+    /**
+     * @param string $cookieDomain set this if you need to write Symplify cookies
+     * on some other domain than what PHP defaults to.
+     */
+    public function __construct(?string $cookieDomain = null)
+    {
+        $this->cookieDomain = $cookieDomain;
+    }
+
     /**
      * Get the HTTP cookie from the current request with the given name.
      */
@@ -19,9 +30,16 @@ final class DefaultCookieJar implements CookieJar
     /**
      * Set the HTTP cookie for the current response, with the given name, the given value.
      */
-    public function setCookie(string $name, string $value): void
+    public function setCookie(string $name, string $value, int $expireInDays): void
     {
-        setcookie($name, $value);
+        $options = array();
+        $options['expires'] = time() + $expireInDays * 60 * 60 * 24;
+
+        if (!is_null($this->cookieDomain)) {
+            $options['domain'] = $this->cookieDomain;
+        }
+
+        setcookie($name, $value, $options);
     }
 
 }

--- a/src/Cookies/SymplifyCookie.php
+++ b/src/Cookies/SymplifyCookie.php
@@ -84,7 +84,7 @@ final class SymplifyCookie
     public function saveTo(CookieJar $cookies): void
     {
         $jsonValue = json_encode($this->underlying);
-        $cookies->setCookie(self::JSON_COOKIE_NAME, $jsonValue);
+        $cookies->setCookie(self::JSON_COOKIE_NAME, $jsonValue, 90);
     }
 
     /**

--- a/tests/TestCookieJar.php
+++ b/tests/TestCookieJar.php
@@ -12,7 +12,7 @@ final class TestCookieJar implements CookieJar
         return $this->cookies[$name] ?? null;
     }
 
-    public function setCookie(string $name, string $value): void
+    public function setCookie(string $name, string $value, int $expireInDays = 90): void //phpcs:ignore
     {
         $this->cookies[$name] = $value;
     }


### PR DESCRIPTION
Problem
======

Our default cookie jar helper only sets session cookies, and only on the domain for the host the server is bound to.

Solution
======

Set the expires and domain cookie options. Allow users to override the cookie domain when configuring their SDK instance.