### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2022-06-23
 ### Added
 - handle optin cookie
 - cookies: make domain overridable, set expires
@@ -33,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - use PSR-3 for logging
   - use PSR-17,PSR-18 for configuration download
 
-[Unreleased]: https://github.com/SymplifyConversion/sst-sdk-php/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/SymplifyConversion/sst-sdk-php/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/SymplifyConversion/sst-sdk-php/releases/tag/v0.2.0
 [0.1.1]: https://github.com/SymplifyConversion/sst-sdk-php/releases/tag/v0.1.1
 [0.1.0]: https://github.com/SymplifyConversion/sst-sdk-php/releases/tag/v0.1.0


### PR DESCRIPTION
Time to release!

New from last release:

### Added
- handle optin cookie
- cookies: make domain overridable, set expires
- persist allocations in cookie, we want it stable even if config changes
- add data driven SDK compatibility test suite

### Changed
- Bump guzzle dependency in example code (CVE-2022-31090, CVE-2022-31091)
- move cookie handling out from visitor module, needed for allocations as well
- total weight is always 100, allows for projects without full allocation
- don't allocate if project is inactive
- Bump guzzle dependency in example code (CVE-2022-31042, CVE-2022-31043)
