### PR TITLE
Fixes numberFun behavior on stringed numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- changed is_numeric to is_int and is_float because of differences in behavior between PHP 7 and PHP 8
 
 ## [0.4.1] - 2022-10-04
 

--- a/src/Audience/Primitives.php
+++ b/src/Audience/Primitives.php
@@ -167,9 +167,9 @@ final class Primitives
      */
     private static function numberFun($a, $b, callable $function, bool $isTrace = false)
     {
-        if (!is_numeric($a) || !is_numeric($b))
-
+        if ((!is_int($a) && !is_float($a) || !is_int($b) && !is_float($b))) {
             return self::isError('expected number arguments', $isTrace);
+        }
 
         return $function((float)$a, (float)$b);
     }


### PR DESCRIPTION
is_numeric is behaving different in 7.4 then 8, causing missmatch when sending a number as a string in rules.