### PR TITLE
Release v0.4.1 - Fixing issue with is_numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.2] - 2022-11-29
+
+### Changed
 - changed is_numeric to is_int and is_float because of differences in behavior between PHP 7 and PHP 8
 
 ## [0.4.1] - 2022-10-04


### PR DESCRIPTION
Time to release!

New from last release:

## [0.4.2] - 2022-11-29

### Changed
- changed is_numeric to is_int and is_float because of differences in behavior between PHP 7 and PHP 8