### PR TITLE
Add reference to sst-documenation repository for cookie information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- add reference in documentation to [SST-documentation](https://github.com/SymplifyConversion/sst-documentation/)
+  repository regarding cookie usage and setup
+
 ## [0.4.2] - 2022-11-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ $sdk->loadConfig();
 
 See more examples of code using the SDK in [examples](examples).
 
+### Cookies
+
+To ensure visitors get the same variation consistently, the SDK needs to
+read and write cookies. See [SST-documentation](https://github.com/SymplifyConversion/sst-documentation/) 
+repository for general cookie setup information and [examples](examples) folder for code examples.
+
 ### Custom audience
 
 It's possible to limit for which requests/visitors a certain test project


### PR DESCRIPTION
### Changed
- add reference in documentation to [SST-documentation](https://github.com/SymplifyConversion/sst-documentation/) repository regarding cookie usage and setup