### PR TITLE
Release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2023-03-20
+
 ### Changed
 - add reference in documentation to [SST-documentation](https://github.com/SymplifyConversion/sst-documentation/)
   repository regarding cookie usage and setup
@@ -65,7 +67,10 @@ It is now located in [SST-documentations docs folder](https://github.com/Symplif
   - use PSR-3 for logging
   - use PSR-17,PSR-18 for configuration download
 
-[Unreleased]: https://github.com/SymplifyConversion/sst-sdk-php/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/SymplifyConversion/sst-sdk-php/compare/v0.4.3...HEAD
+[0.4.3]: https://github.com/SymplifyConversion/sst-sdk-php/releases/tag/v0.4.3
+[0.4.2]: https://github.com/SymplifyConversion/sst-sdk-php/releases/tag/v0.4.2
+[0.4.1]: https://github.com/SymplifyConversion/sst-sdk-php/releases/tag/v0.4.1
 [0.4.0]: https://github.com/SymplifyConversion/sst-sdk-php/releases/tag/v0.4.0
 [0.2.0]: https://github.com/SymplifyConversion/sst-sdk-php/releases/tag/v0.2.0
 [0.1.1]: https://github.com/SymplifyConversion/sst-sdk-php/releases/tag/v0.1.1


### PR DESCRIPTION
### Changed
- add reference in documentation to [SST-documentation](https://github.com/SymplifyConversion/sst-documentation/) repository regarding cookie usage and setup